### PR TITLE
fix: description이 제대로 표시되지 않는 문제 수정

### DIFF
--- a/i18n/ko/docusaurus-plugin-content-docs/current/community/communication.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/community/communication.mdx
@@ -2,6 +2,7 @@
 id: communication
 title: 커뮤니케이션
 sidebar_label: 커뮤니케이션
+description: 커뮤니티에서 주로 다루는 채널은 Slack입니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";

--- a/i18n/ko/docusaurus-plugin-content-docs/current/community/forums.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/community/forums.mdx
@@ -2,6 +2,7 @@
 id: forums
 title: 포럼
 sidebar_label: 포럼
+description: 포럼은 커뮤니티 내에서 지식공유를 원활하게 하기 위해 운영이 되고 있습니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";

--- a/i18n/ko/docusaurus-plugin-content-docs/current/community/meetup.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/community/meetup.mdx
@@ -2,6 +2,7 @@
 id: meetup
 title: 밋업
 sidebar_label: 밋업
+description: 저희 커뮤니티에서는 정기적으로 오프라인 밋업을 진행하고 있습니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";

--- a/i18n/ko/docusaurus-plugin-content-docs/current/community/opensource.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/community/opensource.mdx
@@ -2,6 +2,7 @@
 id: opensource
 title: 오픈 소스
 sidebar_label: 오픈 소스
+description: 커뮤니티에서 현업에 필요한 오픈소스를 발굴하며 공유합니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";

--- a/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development-environment/macos.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development-environment/macos.mdx
@@ -3,6 +3,7 @@ id: macos
 title: 맥 개발 환경
 sidebar_label: 맥 개발 환경
 sidebar_position: 1
+description: 이번 섹션에서는 개발을 입문하는 분들에게도 개발 환경을 설정하는데 도움이 될 수 있도록 자료를 준비했습니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";

--- a/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development-environment/vscode-plugins.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development-environment/vscode-plugins.mdx
@@ -2,6 +2,7 @@
 id: vscode-plugins
 title: VSCode 플러그인
 sidebar_label: VSCode 플러그인
+description: 이번 섹션에서는 Visual Studio Code에서 개발을 하기 위해 필수로 필요한 플러그인에 대해 알아봅니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";

--- a/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development-environment/windows.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development-environment/windows.mdx
@@ -2,6 +2,7 @@
 id: windows
 title: 윈도우 개발 환경
 sidebar_label: 윈도우 개발 환경
+description: 이번 섹션에서는 개발을 입문하는 분들에게도 개발 환경을 설정하는데 도움이 될 수 있도록 자료를 준비했습니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";

--- a/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development/folder-structure.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development/folder-structure.mdx
@@ -2,6 +2,7 @@
 id: folder-structure
 title: 폴더 구조
 sidebar_label: 폴더 구조
+description: 개발 과정에서 폴더 구조를 결정하는 것은 여전히 많은 개발자들에게 중요한 도전 과제 중 하나입니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";

--- a/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development/start.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/react-native/development/start.mdx
@@ -2,6 +2,7 @@
 id: start
 title: 프로젝트 시작하기
 sidebar_label: 프로젝트 시작하기
+description: 우리 커뮤니티에서는 처음부터 앱 개발 과정을 직접 경험하면서, 이를 통해 입문자들에게 유익한 자료와 지침을 제공하려고 합니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";

--- a/i18n/ko/docusaurus-plugin-content-docs/current/react-native/router/expo-router.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/react-native/router/expo-router.mdx
@@ -2,6 +2,7 @@
 id: expo-router
 title: 엑스포 라우터
 sidebar_label: 엑스포 라우터
+description: 라우터 섹션에서 설명한 것과 같이 리엑트 네이티브에는 react-navigation, react-native-navigation 등 각종 라우터들이 있지만 저희 커뮤니티에서는 expo-router를 추천합니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";
@@ -51,7 +52,7 @@ function ProfileScreen({ route }) {
 ## Stack
 
 ### 1. Stack Layout이란?
-Expo Router의 Stack Layout은 React Navigation에서 제공하는 Native Stack Navigator를 활용합니다. 이것은 예전에 사용하던 JS Stack Navigator와는 다릅니다. 
+Expo Router의 Stack Layout은 React Navigation에서 제공하는 Native Stack Navigator를 활용합니다. 이것은 예전에 사용하던 JS Stack Navigator와는 다릅니다.
 
 ### 2. 기본 사용법
 ```tsx
@@ -253,10 +254,10 @@ Expo Router의 Drawer 레이아웃을 사용하면 사이드 내비게이션 메
    ```tsx
    module.exports = {
      presets: [
-         ... 
+         ...
        ],
      plugins: [
-       ... 
+       ...
        'react-native-reanimated/plugin',
      ],
    };
@@ -514,15 +515,15 @@ export { default } from '../components/about';
 ```
 app
 ├── _layout.js
-│ 
+│
 ├── (home)
 │   ├── _layout.js
 │   └── [user].js
-│ 
+│
 ├── (search)
 │   ├── _layout.js
 │   └── [user].js
-│ 
+│
 └── (profile)
     ├── _layout.js
     └── [user].js

--- a/i18n/ko/docusaurus-plugin-content-docs/current/react-native/router/router.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/react-native/router/router.mdx
@@ -3,6 +3,7 @@ id: router
 title: 라우터
 sidebar_label: 라우터
 sidebar_position: 1
+description: 리액트 네이티브에서는 라우터나 네비게이션 관리를 위해 여러 패키지가 있습니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";
@@ -16,7 +17,7 @@ import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";
 
 ## 1. React Navigation
 
-[React Navigation](https://reactnavigation.org)은 리액트 네이티브에서 가장 인기 있는 네비게이션 라이브러리 중 하나입니다. 
+[React Navigation](https://reactnavigation.org)은 리액트 네이티브에서 가장 인기 있는 네비게이션 라이브러리 중 하나입니다.
 
 ### 장점
 - 자바스크립트로 구현되어 있어, 다양한 플랫폼에서의 호환성이 좋습니다.

--- a/i18n/ko/docusaurus-plugin-content-docs/current/react-native/style/built-in.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/react-native/style/built-in.mdx
@@ -2,6 +2,7 @@
 id: built-in
 title: 내장 스타일링
 sidebar_label: 내장 스타일링
+description: 애플리케이션을 개발할 때, 모바일이나 웹에 관계없이 사용자에게 어떻게 보이고 느껴지는지가 중요합니다.
 ---
 
 import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";
@@ -46,7 +47,7 @@ import AdFitMobileBanner from "@site/src/uis/AdFitMobileBanner";
    ```tsx
    import React from 'react';
    import { View, Text } from 'react-native';
-   
+
    export default function App() {
      return (
        <View style={styles.container}>


### PR DESCRIPTION
## 문제점

일부 화면에 설명문(description)이 아닌 `<AdFitMobileBanner`이 표시되는 문제가 있습니다.

<img width="1724" alt="スクリーンショット 2024-08-15 20 47 03" src="https://github.com/user-attachments/assets/cf981735-01cb-4518-8820-e3c63a231424">

## 원인

`Docusaurus`는 기본적으로 Markdown 파일의 첫번째 줄을 설명문으로 사용합니다.

- Document: https://docusaurus.io/docs/markdown-features/head-metadata#markdown-page-description

<img width="960" alt="スクリーンショット 2024-08-15 21 39 29" src="https://github.com/user-attachments/assets/a5572dbf-8266-4fb9-944f-84fe9e18c7df">


그래서 다른 설명문보다 먼저 `<AdFitMobileBanner>`를 사용하는 곳에서는 `<AdFitMobileBanner`를 설명문으로 인식하는 문제가 있습니다.

## 수정

`<AdFitMobileBanner>`이 설명문보다 먼저 사용되는 곳 중에서 `<AdFitMobileBanner` 문자열이 표시되어 화면 상에 문제가 되는 곳에 `description` 필드를 수동으로 설정하였습니다.

`description` 필드에는 본문의 첫번째 문장을 설정하였습니다.

## 수정 영역

다음과 같이 화면에 `<AdFitMobileBanner`이 표시되는 문제를 수정하였습니다.

| 수정전 | 수정후 |
| -- | -- |
| <img width="1724" alt="スクリーンショット 2024-08-15 20 47 03" src="https://github.com/user-attachments/assets/b6bac253-d66e-4742-9abc-b714edc0cf81"> | <img width="1724" alt="スクリーンショット 2024-08-15 21 16 49" src="https://github.com/user-attachments/assets/e9919f66-0560-4600-b875-21953294abfa"> |
| <img width="1724" alt="スクリーンショット 2024-08-15 21 17 21" src="https://github.com/user-attachments/assets/a0d5e6ea-3aaa-4cb3-94cf-fe77f08a4041"> | <img width="1724" alt="スクリーンショット 2024-08-15 21 17 56" src="https://github.com/user-attachments/assets/d5a68522-ca59-4dda-bfa2-867adb068849"> |
| <img width="1724" alt="スクリーンショット 2024-08-15 21 18 42" src="https://github.com/user-attachments/assets/f9cb6f41-b1d5-4b4c-acad-a202dde961a2"> | <img width="1724" alt="スクリーンショット 2024-08-15 21 19 26" src="https://github.com/user-attachments/assets/103e8fee-ee86-4f8a-8cab-2c6647f09813"> |
| <img width="1724" alt="スクリーンショット 2024-08-15 21 19 52" src="https://github.com/user-attachments/assets/c29ac02c-1cb4-4ea3-869b-c69f294d2632"> | <img width="1724" alt="スクリーンショット 2024-08-15 21 24 06" src="https://github.com/user-attachments/assets/1e7ddc85-904f-4a46-b793-ee449bc462d9"> |
